### PR TITLE
Easing specification for react-native docs

### DIFF
--- a/react-native/react-native.md
+++ b/react-native/react-native.md
@@ -45,7 +45,7 @@ Lottie's animation progress can be controlled with an `Animated` value:
 
 ```jsx
 import React from 'react';
-import { Animated } from 'react-native';
+import { Animated, Easing } from 'react-native';
 import Animation from 'lottie-react-native';
 
 export default class BasicExample extends React.Component {
@@ -60,6 +60,7 @@ export default class BasicExample extends React.Component {
     Animated.timing(this.state.progress, {
       toValue: 1,
       duration: 5000,
+      easing: Easing.linear,
     }).start();
   }
 


### PR DESCRIPTION
`Animated.timing` uses `Easing.inOut` easing by default: https://cl.ly/0L2G0w3v120r.

Without specifying linear easing, you're actually applying easing to the timing—in this example, as it goes from 1 to 5,000. So, if we're using e.g. 60 fps, we'll be showing the correct content at frame 1, frame 150, and frame 300…but everything in between is going to be slightly off.

I didn't check if this also needs to be fixed in the imperative API's implementation details, but you might want to.