### PR TITLE
Fix row "Range selector (Ease low)" missing a pipe character

### DIFF
--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -84,7 +84,7 @@
 | Range selector (Amount) |       ⛔ | ⛔️ | 👍 | 👍 | 👍 |
 | Range selector (Shape) |        ⛔ | ⛔️ | 👍 | 👍 | 👍 |
 | Range selector (Ease High) |    ⛔ | ⛔️ | 👍 | 👍 | 👍 |
-| Range selector (Ease Low)       ⛔ | ⛔️ | 👍 | 👍 | 👍 |
+| Range selector (Ease Low) |     ⛔ | ⛔️ | 👍 | 👍 | 👍 |
 | Range selector (Randomize order) | ⛔ | ⛔️ | 👍 | 👍 | 👍 |
 | expression selector |           ⛔ | ⛔️ | 👍 | 👍 | 👍 |
 | **Other** | **Android** | **iOS** | **Web (SVG)** | **Web (Canvas)** | **Web (HTML)** |


### PR DESCRIPTION
Fixes a missing pipe in the Markdown source. Should presumably fix http://airbnb.io/lottie/supported-features.html as well