### PR TITLE
Update base URL to prevent broken edit link in docs

### DIFF
--- a/book.json
+++ b/book.json
@@ -24,7 +24,7 @@
   ],
   "pluginsConfig": {
     "edit-link": {
-      "base": "https://github.com/airbnb/lottie",
+      "base": "https://github.com/airbnb/lottie/edit/lottie-docs/docs/",
       "label": "Edit This Page"
     },
     "github": {


### PR DESCRIPTION
The base URL should use the `edit` path on the `lottie-docs` branch, scoped to the `/docs` directory, otherwise the edit link will try to go to `https://github.com/airbnb/lottie/foobar.md` and 404.