### PR TITLE
Add import to RN android installation guide

### DIFF
--- a/docs/react-native/react-native.md
+++ b/docs/react-native/react-native.md
@@ -66,6 +66,10 @@ android {
 You must also add the `LottiePackage` to `getPackages()` in your `ReactApplication`
 
 ```java
+    import com.airbnb.android.react.lottie.LottiePackage;
+    
+    ...
+    
     @Override
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(


### PR DESCRIPTION
Currently the android manual linking installation guide for RN says to add the `LottiePackage` to the list of RN packages in `build.gradle` but doesn't mention importing the package first.

This PR just clarifies it a bit.