### PR TITLE
compile is obsolete

### DIFF
--- a/docs/android/android.md
+++ b/docs/android/android.md
@@ -3,7 +3,7 @@ Gradle is the only supported build configuration, so just add the dependency to 
 
 <pre><code class="lang-groovy">dependencies {
     ...
-    compile 'com.airbnb.android:lottie:{{ book.androidVersion }}'
+    implementation 'com.airbnb.android:lottie:{{ book.androidVersion }}'
     ...
 }
 </code></pre>


### PR DESCRIPTION
While using compile in the android studio it throws an error like Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.It will be removed at the end of 2018. For more information see: [http://d.android.com/r/tools/update-dependency-configurations.html](http://d.android.com/r/tools/update-dependency-configurations.html)

So the documentation is changed so that people won't be confused.



