### PR TITLE
Update the Gradle configuration

### DIFF
--- a/docs/android/android.md
+++ b/docs/android/android.md
@@ -3,7 +3,7 @@ Gradle is the only supported build configuration, so just add the dependency to 
 
 <pre><code class="lang-groovy">dependencies {
     ...
-    compile 'com.airbnb.android:lottie:{{ book.androidVersion }}'
+    implementation 'com.airbnb.android:lottie:{{ book.androidVersion }}'
     ...
 }
 </code></pre>


### PR DESCRIPTION
Change the configuration of the dependency declaration to new `implementation` mode. It is one of the breaking changes coming with Gradle: 3.0 that Google announced at IO17.