### PR TITLE
Typo fix in doc

### DIFF
--- a/docs/community-showcase.md
+++ b/docs/community-showcase.md
@@ -26,7 +26,7 @@ SwiftKey iOS is using Lottie to help guide their users through the installation 
 
 
 ## Elevate
-Elevate used a combination of shape layers, alpha mattes and images to craft this silky smooth walkthrough where illstrations seamlessly mortph as users swipe to select different training options.
+Elevate used a combination of shape layers, alpha mattes and images to craft this silky smooth walkthrough where illustrations seamlessly morph as users swipe to select different training options.
 
 ![Elevate](/images/ShowcaseElevate.gif)
 


### PR DESCRIPTION
- "illustrations" instead of "illstrations"
- "morph" instead of "mortph"