### PR TITLE
Added a link to rlottie library

### DIFF
--- a/other-platforms.md
+++ b/other-platforms.md
@@ -6,6 +6,7 @@ The Lottie community has build Lottie bindings for the following platforms:
 * [NativeScript](https://github.com/bradmartin/nativescript-lottie)
 * [Axway Appcelerator](https://github.com/m1ga/ti.animation)
 * [Qt QML](https://sea-region.github.com/kbroulik/lottie-qml)
+* [Rlottie](https://github.com/Samsung/rlottie)
 
 # Web
 * [React](https://github.com/chenqingspring/react-lottie)


### PR DESCRIPTION
rlottie is a platform independent standalone c++ library. currently used in Tizen Platform. 