### PR TITLE
docs: fix markdown syntax

### DIFF
--- a/web.md
+++ b/web.md
@@ -74,28 +74,28 @@ lottie.loadAnimation({
 
 ## Usage
 animation instances have these main methods:
-**anim.play()** <br/>
-**anim.stop()** <br/>
-**anim.pause()** <br/>
-**anim.setLocationHref(locationHref)** -- one param usually pass as `location.href`. Its useful when you experience mask issue in safari where your url does not have `#` symbol. <br/>
-**anim.setSpeed(speed)** -- one param speed (1 is normal speed) <br/>
-**anim.goToAndStop(value, isFrame)** first param is a numeric value. second param is a boolean that defines time or frames for first param <br/>
-**anim.goToAndPlay(value, isFrame)** first param is a numeric value. second param is a boolean that defines time or frames for first param <br/>
-**anim.setDirection(direction)** -- one param direction (1 is normal direction.) <br/>
-**anim.playSegments(segments, forceFlag)** -- first param is a single array or multiple arrays of two values each(fromFrame,toFrame), second param is a boolean for forcing the new segment right away<br/>
-**anim.setSubframe(flag)** -- If false, it will respect the original AE fps. If true, it will update as much as possible. (true by default)<br/>
-**anim.destroy()**<br/>
+- **anim.play()**
+- **anim.stop()**
+- **anim.pause()**
+- **anim.setLocationHref(locationHref)** -- one param usually pass as `location.href`. Its useful when you experience mask issue in safari where your url does not have `#` symbol.
+- **anim.setSpeed(speed)** -- one param speed (1 is normal speed)
+- **anim.goToAndStop(value, isFrame)** first param is a numeric value. second param is a boolean that defines time or frames for first param
+- **anim.goToAndPlay(value, isFrame)** first param is a numeric value. second param is a boolean that defines time or frames for first param
+- **anim.setDirection(direction)** -- one param direction (1 is normal direction.)
+- **anim.playSegments(segments, forceFlag)** -- first param is a single array or multiple arrays of two values each(fromFrame,toFrame), second param is a boolean for forcing the new segment right awa
+- **anim.setSubframe(flag)** -- If false, it will respect the original AE fps. If true, it will update as much as possible. (true by default
+- **anim.destroy()**
 
 lottie has 8 main methods:
-**lottie.play()** -- with 1 optional parameter **name** to target a specific animation <br/>
-**lottie.stop()** -- with 1 optional parameter **name** to target a specific animation <br/>
-**lottie.setSpeed()** -- first param speed (1 is normal speed) -- with 1 optional parameter **name** to target a specific animation <br/>
-**lottie.setDirection()** -- first param direction (1 is normal direction.) -- with 1 optional parameter **name** to target a specific animation <br/>
-**lottie.searchAnimations()** -- looks for elements with class "lottie" <br/>
-**lottie.loadAnimation()** -- Explained above. returns an animation instance to control individually. <br/>
-**lottie.destroy()** -- To destroy and release resources. The DOM element will be emptied.<br />
-**lottie.registerAnimation()** -- you can register an element directly with registerAnimation. It must have the "data-animation-path" attribute pointing at the data.json url<br />
-**lottie.setQuality()** -- default 'high', set 'high','medium','low', or a number > 1 to improve player performance. In some animations as low as 2 won't show any difference.<br />
+- **lottie.play()** -- with 1 optional parameter **name** to target a specific animation 
+- **lottie.stop()** -- with 1 optional parameter **name** to target a specific animation 
+- **lottie.setSpeed()** -- first param speed (1 is normal speed) -- with 1 optional parameter **name** to target a specific animation 
+- **lottie.setDirection()** -- first param direction (1 is normal direction.) -- with 1 optional parameter **name** to target a specific animation 
+- **lottie.searchAnimations()** -- looks for elements with class "lottie" 
+- **lottie.loadAnimation()** -- Explained above. returns an animation instance to control individually.
+- **lottie.destroy()** -- To destroy and release resources. The DOM element will be emptied. 
+- **lottie.registerAnimation()** -- you can register an element directly with registerAnimation. It must have the "data-animation-path" attribute pointing at the data.json url 
+- **lottie.setQuality()** -- default 'high', set 'high','medium','low', or a number > 1 to improve player performance. In some animations as low as 2 won't show any difference. 
 
 ## Events
 - onComplete
@@ -132,31 +132,30 @@ lottie.loadAnimation({
 });
 ```
 Doing this you will have to handle the canvas clearing after each frame
-<br/>
+
 Another way to load animations is adding specific attributes to a dom element.
 You have to include a div and set it's class to lottie.
 If you do it before page load, it will automatically search for all tags with the class "lottie".
 Or you can call lottie.searchAnimations() after page load and it will search all elements with the class "lottie".
-<br/>
+
 - add the data.json to a folder relative to the html
 - create a div that will contain the animation.
-<br/>
- **Required**
- <br/>
- . a class called "lottie"
- . a "data-animation-path" attribute with relative path to the data.json
- <br/>
+
+**Required**
+
+- a class called "lottie"
+- a "data-animation-path" attribute with relative path to the data.json
+
 **Optional**
-<br/>
- . a "data-anim-loop" attribute
- . a "data-name" attribute to specify a name to target play controls specifically
- <br/>
- **Example**
- <br/>
+
+- a "data-anim-loop" attribute
+- a "data-name" attribute to specify a name to target play controls specifically
+
+**Example**
+
 ```html
- <div style="width:1067px;height:600px" class="lottie" data-animation-path="animation/" data-anim-loop="true" data-name="ninja"></div>
+<div style="width:1067px;height:600px" class="lottie" data-animation-path="animation/" data-anim-loop="true" data-name="ninja"></div>
 ```
-<br/>
 
 # Previewing Animations
 


### PR DESCRIPTION
The `web` doc-page looks weird.

![image](https://user-images.githubusercontent.com/19513289/59842951-2f4f3200-938a-11e9-928d-8fd75ed352f0.png)

Beside above, and some ~~pretty format~~