### PR TITLE
Update supported-features.md

### DIFF
--- a/supported-features.md
+++ b/supported-features.md
@@ -78,16 +78,16 @@
 | Stroke |                        👍 | 👍 | ⛔️ | 👍 | 👍 | 👍 |
 | Tracking |                      👍 | 👍 | ⛔️ | 👍 | 👍 | 👍 |
 | Anchor point grouping |         ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
-| Text Path |                     ⛔ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
-| Per-character 3D |              ⛔ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
-| Range selector (Units) |        ⛔ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
-| Range selector (Based on) |     ⛔ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
-| Range selector (Amount) |       ⛔ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
-| Range selector (Shape) |        ⛔ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
-| Range selector (Ease High) |    ⛔ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
-| Range selector (Ease Low)  |    ⛔ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
-| Range selector (Randomize order) | ⛔ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
-| expression selector |           ⛔ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
+| Text Path |                     ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
+| Per-character 3D |              ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
+| Range selector (Units) |        ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
+| Range selector (Based on) |     ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
+| Range selector (Amount) |       ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
+| Range selector (Shape) |        ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
+| Range selector (Ease High) |    ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
+| Range selector (Ease Low)  |    ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
+| Range selector (Randomize order) | ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
+| expression selector |           ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
 | **Other** | **Android** | **iOS** | **Windows** | **Web (SVG)** | **Web (Canvas)** | **Web (HTML)** |
 | Expressions |                   ⛔️ | ⛔️ | ⛔️ | 👍 | 👍 | 👍 |
 | Images |                        👍 | 👍 | ⛔️ | 👍 | 👍 | 👍 |


### PR DESCRIPTION
Very small fix on the supported-features .md, where on the Android column some of the emojis were displaying with a smaller size, causing some visual imbalance 🕵.

Replaced the ⛔️emojis for the same emoji, with the proper size, on the `Text` area.

<img width="382" alt="Screenshot 2019-08-05 at 11 09 16" src="https://user-images.githubusercontent.com/2558808/62453189-1819a780-b772-11e9-8490-64de238eb67a.png">
<img width="377" alt="Screenshot 2019-08-05 at 11 09 24" src="https://user-images.githubusercontent.com/2558808/62453192-1a7c0180-b772-11e9-8fd1-4ac6d0f4c3cc.png">
