### PR TITLE
Fixed supported after effects features table

### DIFF
--- a/ios.md
+++ b/ios.md
@@ -742,6 +742,7 @@ Lottie allows you to change **any** property that is animatable in After Effects
 ## Supported After Effects Features
 
 See Supported Features by platform [here](/supported-features.md)
+
 | **Shapes** | **2.5.2** | **3.0** |
 |:--|:-:|:-:|
 | Shape | 👍 | 👍 |


### PR DESCRIPTION
Supported after effects features was not displayed as a tables so I fixed it. 😄

|before|after|
|:--:|:--:|
|<img width="889" alt="Screen Shot 2019-12-17 at 7 19 53" src="https://user-images.githubusercontent.com/24249859/70947952-b82afa00-209d-11ea-8af9-7da3856dd914.png">|<img width="411" alt="Screen Shot 2019-12-17 at 7 20 09" src="https://user-images.githubusercontent.com/24249859/70947967-c24cf880-209d-11ea-9279-59d376ff720d.png">|