### PR TITLE
Add &nbsp; to preserve white space

### DIFF
--- a/home.md
+++ b/home.md
@@ -1,4 +1,4 @@
-# Lottie for [Android](https://github.com/airbnb/lottie-android), [iOS](https://github.com/airbnb/lottie-ios), [Web](https://github.com/airbnb/lottie-web), [React Native](https://github.com/airbnb/lottie-react-native), and [Windows](https://aka.ms/lottie)
+# Lottie for&nbsp;[Android](https://github.com/airbnb/lottie-android), [iOS](https://github.com/airbnb/lottie-ios), [Web](https://github.com/airbnb/lottie-web), [React Native](https://github.com/airbnb/lottie-react-native), and [Windows](https://aka.ms/lottie)
 
 <table>
   <tr>

--- a/web.md
+++ b/web.md
@@ -45,7 +45,12 @@ bower install lottie-web
 ```
 
 ---
-#  [Video tutorial](https://www.youtube.com/watch?v=5XMUJdjI0L8)
+#  Video tutorial 
+
+<div style="position: relative; width: 100%; height: 0; padding-bottom: 56.25%;">
+<iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/5XMUJdjI0L8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 ---
 
 # Usage


### PR DESCRIPTION
Markdown was neglecting the white space between "for" and "Android". 
Before: 
![image](https://user-images.githubusercontent.com/53514599/101879584-e79f1480-3bd4-11eb-8ec8-a9457f1a6064.png)
After:
![image](https://user-images.githubusercontent.com/53514599/101879459-b7577600-3bd4-11eb-850f-6d43750782d5.png)
