### PR TITLE
Update broken image file address

### DIFF
--- a/home.md
+++ b/home.md
@@ -6,7 +6,7 @@
       <a href='https://play.google.com/store/apps/details?id=com.airbnb.lottie'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="80px"/></a>
     </th>
     <th>
-      <a href='https://www.microsoft.com/store/apps/9p7x9k692tmw?ocid=badge'><img src='https://assets.windowsphone.com/13484911-a6ab-4170-8b7e-795c1e8b4165/English_get_L_InvariantCulture_Default.png' alt='English badge' width='127px' height='52px'/></a>
+      <a href='https://www.microsoft.com/store/apps/9p7x9k692tmw?ocid=badge'><img src='https://developer.microsoft.com/store/badges/images/English_get-it-from-MS.png' alt='English badge' width='127px' height='52px'/></a>
     </th> 
   </tr>
 </table>


### PR DESCRIPTION
Previous image asset for "Get it from Microsoft" badge seems to be broken. Replaced image link by official badge creation site from Microsoft at [here](https://developer.microsoft.com/en-us/store/badges/).