### PR TITLE
Fix args order for Compose LottieAnimation example

### DIFF
--- a/android-compose.md
+++ b/android-compose.md
@@ -67,8 +67,8 @@ fun Loader() {
 
     LottieAnimation(
         animationSpec,
-        animationState,
-        modifier = Modifier.preferredSize(100.dp)
+        modifier = Modifier.preferredSize(100.dp),
+        animationState
     )
 }
 ```


### PR DESCRIPTION
According to the source code, the `animationState` is the third arg. I simply switched the order.