### PR TITLE
chore: update docs to reflect latest Compose API changes

### DIFF
--- a/android-compose.md
+++ b/android-compose.md
@@ -53,7 +53,7 @@ fun Loader() {
     val animationSpec = remember { LottieAnimationSpec.RawRes(R.raw.loading) }
     LottieAnimation(
         animationSpec,
-        modifier = Modifier.preferredSize(100.dp)
+        modifier = Modifier.size(100.dp)
     )
 }
 ```
@@ -68,7 +68,7 @@ fun Loader() {
     LottieAnimation(
         animationSpec,
         animationState,
-        modifier = Modifier.preferredSize(100.dp)
+        modifier = Modifier.size(100.dp)
     )
 }
 ```


### PR DESCRIPTION
Updating usages of size modifiers in the sample code blocks, since they were renamed in beta01. Modifier.preferredWidth/preferredHeight/preferredSize were renamed to width/height/size. [I5b414](https://android-review.googlesource.com/#/q/I5b4145953d360b1fb851c0056fc9a7875bb34088)

cc @gpeal 