### PR TITLE
Updated to reference LottieComposeSpec

### DIFF
--- a/android-compose.md
+++ b/android-compose.md
@@ -26,7 +26,7 @@ The latest snapshot version is: ![lottieSnapshotVersion](https://img.shields.io/
 ```kotlin
 @Composable
 fun Loader() {
-    val composition by rememberLottieComposition(LottieAnimationSpec.RawRes(R.raw.loading))
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.loading))
     val progress by animateLottieCompositionAsState(composition)
     LottieAnimation(
         composition,
@@ -38,7 +38,7 @@ Or with the `LottieAnimation` overload that merges `LottieAnimation` and `animat
 ```kotlin
 @Composable
 fun Loader() {
-    val composition by rememberLottieComposition(LottieAnimationSpec.RawRes(R.raw.loading))
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.loading))
     LottieAnimation(composition)
 }
 ```


### PR DESCRIPTION
The docs for Lottie Compose seem to reference the incorrect `LottieAnimationSpec` which doesn't seem to exist in the latest Lottie Compose version. This PR updates the docs to point to `LottieCompositionSpec` instead. 