### PR TITLE
Use `bodymovin` name for bower

### DIFF
--- a/web.md
+++ b/web.md
@@ -41,7 +41,7 @@ npm install lottie-web
 
 ## Bower
 ```bash
-bower install lottie-web
+bower install bodymovin
 ```
 
 ---


### PR DESCRIPTION
## Changes
* use `bodymovin` in bower install documentation instead of `lottie-web`


## Rationale

Installation fails if `lottie-web` is used as documented

Example:

![Screen Shot 2021-07-27 at 3 55 04 PM](https://user-images.githubusercontent.com/5113432/127219432-da1ab6e1-ebf4-45ed-ac9e-c51fb0ae7217.png)

`bodymovin` name still in use by bower.
https://github.com/airbnb/lottie-web/blob/master/bower.json#L2

Example:

![Screen Shot 2021-07-27 at 3 51 00 PM](https://user-images.githubusercontent.com/5113432/127219446-89a08cdd-ce2a-48e5-8f13-bc4914efb7b4.png)
