### PR TITLE
Fix typo in android-compose documentation

### DIFF
--- a/android-compose.md
+++ b/android-compose.md
@@ -148,8 +148,8 @@ class MyHoistedState {
 }
 ```
 ```kotlin
-val composition = rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.animation))
-val lottieAnimatable by rememberLottieAnimatable()
+val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.animation))
+val lottieAnimatable = rememberLottieAnimatable()
 LaunchedEffect(Unit) {
     lottieAnimatable.animate(
         composition,


### PR DESCRIPTION
I might be wrong and please discard this PR if I am, but from the documentation of rememberLottieAnimatable it does not return a State. When I tested it out in another project, this was the only way I could make it work :) 