### PR TITLE
Fix errant LottieAnimationSpec references in Android Compose docs

### DIFF
--- a/android-compose.md
+++ b/android-compose.md
@@ -26,7 +26,7 @@ The latest snapshot version is: ![lottieSnapshotVersion](https://img.shields.io/
 ```kotlin
 @Composable
 fun Loader() {
-    val composition by rememberLottieComposition(LottieAnimationSpec.RawRes(R.raw.loading))
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.loading))
     val progress by animateLottieCompositionAsState(composition)
     LottieAnimation(
         composition,
@@ -38,7 +38,7 @@ Or with the `LottieAnimation` overload that merges `LottieAnimation` and `animat
 ```kotlin
 @Composable
 fun Loader() {
-    val composition by rememberLottieComposition(LottieAnimationSpec.RawRes(R.raw.loading))
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.loading))
     LottieAnimation(composition)
 }
 ```


### PR DESCRIPTION
The docs update for the `LottieAnimationSpec`﻿-> `LottieCompositionSpec` rename in the Compose implementation missed a couple instances of the old API, which are [confusing end users](https://twitter.com/lehtimaeki/status/1435179416540401668) trying out the library. This PR updates those references to correctly use `LottieCompositionSpec`.
