### PR TITLE
Adding Flutter Lottie wrapper on third party platforms page

### DIFF
--- a/other-platforms.md
+++ b/other-platforms.md
@@ -9,6 +9,7 @@ The Lottie community has build Lottie bindings for the following platforms:
 * [Rlottie](https://github.com/Samsung/rlottie)
 * [Python](https://gitlab.com/mattia.basaglia/python-lottie)
 * [MIT Appinventor](https://community.appinventor.mit.edu/t/lottie-animations-add-cool-animations-to-your-apps/44483/)
+* [Flutter](https://github.com/xvrh/lottie-flutter)
 
 # Web
 * [React](https://github.com/chenqingspring/react-lottie)


### PR DESCRIPTION
- Adding reference to the Flutter Lottie package as a third party platform