### PR TITLE
Fixed 'instal' typo on contribute page

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -6,7 +6,7 @@ To do that, find the markdown file with the docs you want to edit and follow [Gi
 [http://airbnb.io/lottie](http://airbnb.io/lottie) runs on [docsify](https://docsify.js.org/#/?id=docsify). Docsify was chosen because it takes hosted markdown and generates the page dynamically. That means that simply updating the markdown files here is all that is needed to update [http://airbnb.io/lottie](http://airbnb.io/lottie).
 
 1. Fork and clone this repo.
-1. Install docsify: `sudo npm instal -g docsify-cli`.
+1. Install docsify: `sudo npm install -g docsify-cli`.
 1. Startup the local docsify server with `docsify serve .` from the root of this repo.
 1. Edit the markdown and verify your changes on the localhost url outputted from the `docsify serve` command.
 1. Put up a pull request to this repo and tag `@gpeal`


### PR DESCRIPTION
I have fixed **'instal' -> 'install'** typo on contribute page (docs.md file).
please review and merge PR.