### PR TITLE
Update deprecated example in android-compose.md

### DIFF
--- a/android-compose.md
+++ b/android-compose.md
@@ -29,8 +29,8 @@ fun Loader() {
     val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.loading))
     val progress by animateLottieCompositionAsState(composition)
     LottieAnimation(
-        composition,
-        progress,
+        composition = composition,
+        progress = { progress },
     )
 }
 ```


### PR DESCRIPTION
The [current example](http://airbnb.io/lottie/#/android-compose?id=basic-usage) uses deprecated composable, here is a fix 

**Details:**
<img width="967" alt="Screenshot 2022-06-17 at 10 44 46" src="https://user-images.githubusercontent.com/12698708/174262481-3dce94a6-fae3-4843-a0d9-5e2df305c1aa.png">
