### PR TITLE
Small typo in android-compose.md

### DIFF
--- a/android-compose.md
+++ b/android-compose.md
@@ -153,7 +153,7 @@ val lottieAnimatable = rememberLottieAnimatable()
 LaunchedEffect(Unit) {
     lottieAnimatable.animate(
         composition,
-        iteration = LottieConstants.IterateForever,
+        iterations = LottieConstants.IterateForever,
         clipSpec = LottieClipSpec.Progress(0.5f, 0.75f),
     )
 }


### PR DESCRIPTION
One of the examples references `iteration` instead of `iterations`