### PR TITLE
fix: use Titanium SDK for 3rd party framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To do that, find the markdown file with the docs you want to edit and follow [Gi
 * [Skia](https://skia.org/user/modules/skottie)
 * [Xamarin](https://github.com/martijn00/LottieXamarin)
 * [NativeScript](https://github.com/bradmartin/nativescript-lottie)
-* [Axway Appcelerator](https://github.com/m1ga/ti.animation)
+* [Titanium SDK](https://github.com/m1ga/ti.animation)
 * [Qt QML](https://sea-region.github.com/kbroulik/lottie-qml)
 * [Rlottie](https://github.com/Samsung/rlottie)
 * [Python](https://gitlab.com/mattia.basaglia/python-lottie)

--- a/other-platforms.md
+++ b/other-platforms.md
@@ -4,7 +4,7 @@ The Lottie community has build Lottie bindings for the following platforms:
 # Wrappers
 * [Xamarin](https://github.com/martijn00/LottieXamarin)
 * [NativeScript](https://github.com/bradmartin/nativescript-lottie)
-* [Axway Appcelerator](https://github.com/m1ga/ti.animation)
+* [Titanium SDK](https://github.com/m1ga/ti.animation)
 * [Qt QML](https://sea-region.github.com/kbroulik/lottie-qml)
 * [Rlottie](https://github.com/Samsung/rlottie)
 * [Python](https://gitlab.com/mattia.basaglia/python-lottie)
@@ -21,4 +21,3 @@ The Lottie community has build Lottie bindings for the following platforms:
 * [Windows](https://github.com/windows-toolkit/Lottie-Windows)
 * [Qt](https://blog.qt.io/blog/2019/03/08/announcing-qtlottie/)
 * [Skia](https://skia.org/user/modules/skottie)
-


### PR DESCRIPTION
Changing the name of the 3rd party framework link:

old name "Axway Appcelerator" -> new name "Titanium SDK" 

it is not connected to Axway anymore