### PR TITLE
Fixed wrong `lottie-react-native` path in android settings.gradle part

### DIFF
--- a/react-native.md
+++ b/react-native.md
@@ -40,7 +40,7 @@ or you can add it manually:
 
 <pre><code class="lang-groovy">
 include ':lottie-react-native'
-project(':lottie-react-native').projectDir = new File(rootProject.projectDir, '../node_modules/lottie-react-native/src/android')
+project(':lottie-react-native').projectDir = new File(rootProject.projectDir, '../node_modules/lottie-react-native/android')
 </code></pre>
 
 `build.gradle`:


### PR DESCRIPTION
lottie-react-native folder in node_modules path looks like: 
`node_modules/lottie-react-native/android/src/main/java/... `
instead of  
`node_modules/lottie-react-native`**/src**`/android/src/main/java/...`