### PR TITLE
use `implementation` keywords to replace `compile` in build.gradle

### DIFF
--- a/react-native.md
+++ b/react-native.md
@@ -48,7 +48,7 @@ project(':lottie-react-native').projectDir = new File(rootProject.projectDir, '.
 <pre><code class="lang-groovy">
 dependencies {
   ...
-  compile project(':lottie-react-native')
+  implementation project(':lottie-react-native')
   ...
 }
 </code></pre>


### PR DESCRIPTION
currently, compile in build.gradle is deprecated, we need to use `implementation` keywords to replace `compile`