### PR TITLE
fix: Add missing dot for correct method chaining

### DIFF
--- a/ios.md
+++ b/ios.md
@@ -121,7 +121,7 @@ var body: some View {
     }
   
   Button {
-    playbackMode = .playing(fromProgress(0, toProgress: 1, loopMode: .playOnce))
+    playbackMode = .playing(.fromProgress(0, toProgress: 1, loopMode: .playOnce))
   } label: {
     Image(systemName: "play.fill")
   }


### PR DESCRIPTION
## Problem example code
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/ced3c828-e941-473a-8aa9-422cfa473c5a">
While writing an example, I discovered that the method chaining in the current implementation is incorrect due to a missing dot before fromProgress. This causes a syntax error and prevents the code from executing properly.

## Fixing code
<img width="876" alt="image" src="https://github.com/user-attachments/assets/0f669256-442d-45a9-96a4-f0acd67b3a30">
The updated implementation adds the missing dot, ensuring correct method chaining and proper execution of the code.
