### PR TITLE
Add note on CA renderer behaviour limitations

### DIFF
--- a/supported-features.md
+++ b/supported-features.md
@@ -117,7 +117,5 @@ Most animations are rendered exactly the same by both rendering engines, but as 
 
 As of [Lottie 4.0](https://medium.com/airbnb-engineering/announcing-lottie-4-0-for-ios-d4d226862a54), Lottie uses the Core Animation rendering engine by default. If Lottie detects that an animation uses functionality not supported by the Core Animation rendering engine, it will automatically fall back to the Main Thread rendering engine. You can also configure which rendering engine is used by configuring the `LottieConfiguration.renderingEngine`.
 
-#### Note on CoreAnimation Renderer Limitations
-
-> The CoreAnimation renderer might not support certain complex shape configurations, particularly those involving intersecting or subtracting paths. Due to architectural constraints of the CA engine, these cases may render differently compared to the MainThread renderer. This behavior is expected.  
-> For more details, see [GitHub Issue #2631](https://github.com/airbnb/lottie-ios/issues/2613).
+For example, the Core Animation rendering engine might not support certain complex shape configurations, particularly those involving intersecting or subtracting paths. Due to architectural constraints, these cases may render differently compared to the Main Thread rendering engine. This behavior is expected.  
+For more details, see [GitHub Issue #2631](https://github.com/airbnb/lottie-ios/issues/2613).

--- a/supported-features.md
+++ b/supported-features.md
@@ -116,3 +116,8 @@ You can learn more about the Core Animation rendering engine in [this post](http
 Most animations are rendered exactly the same by both rendering engines, but as shown above the Core Animation rendering engine and Main Thread rendering engine support slightly different sets of functionality. 
 
 As of [Lottie 4.0](https://medium.com/airbnb-engineering/announcing-lottie-4-0-for-ios-d4d226862a54), Lottie uses the Core Animation rendering engine by default. If Lottie detects that an animation uses functionality not supported by the Core Animation rendering engine, it will automatically fall back to the Main Thread rendering engine. You can also configure which rendering engine is used by configuring the `LottieConfiguration.renderingEngine`.
+
+#### Note on CoreAnimation Renderer Limitations
+
+> The CoreAnimation renderer might not support certain complex shape configurations, particularly those involving intersecting or subtracting paths. Due to architectural constraints of the CA engine, these cases may render differently compared to the MainThread renderer. This behavior is expected.  
+> For more details, see [GitHub Issue #2631](https://github.com/airbnb/lottie-ios/issues/2613).

--- a/supported-features.md
+++ b/supported-features.md
@@ -113,9 +113,7 @@ Lottie for iOS includes two rendering engine implementations, which are responsi
 
 You can learn more about the Core Animation rendering engine in [this post](https://medium.com/airbnb-engineering/announcing-lottie-4-0-for-ios-d4d226862a54) on Airbnb's Tech Blog: **[Announcing Lottie 4.0 for iOS](https://medium.com/airbnb-engineering/announcing-lottie-4-0-for-ios-d4d226862a54)**.
 
-Most animations are rendered exactly the same by both rendering engines, but as shown above the Core Animation rendering engine and Main Thread rendering engine support slightly different sets of functionality. 
+Most animations are rendered exactly the same by both rendering engines, but as shown above the Core Animation rendering engine and Main Thread rendering engine support slightly different sets of functionality. For example, the Core Animation rendering engine might not support certain complex shape configurations, particularly those involving intersecting or subtracting paths. Due to architectural constraints, these cases may render differently compared to the Main Thread rendering engine. This behavior is expected.  
+For more details, see [GitHub Issue #2631](https://github.com/airbnb/lottie-ios/issues/2613).
 
 As of [Lottie 4.0](https://medium.com/airbnb-engineering/announcing-lottie-4-0-for-ios-d4d226862a54), Lottie uses the Core Animation rendering engine by default. If Lottie detects that an animation uses functionality not supported by the Core Animation rendering engine, it will automatically fall back to the Main Thread rendering engine. You can also configure which rendering engine is used by configuring the `LottieConfiguration.renderingEngine`.
-
-For example, the Core Animation rendering engine might not support certain complex shape configurations, particularly those involving intersecting or subtracting paths. Due to architectural constraints, these cases may render differently compared to the Main Thread rendering engine. This behavior is expected.  
-For more details, see [GitHub Issue #2631](https://github.com/airbnb/lottie-ios/issues/2613).


### PR DESCRIPTION
Changes include:
- explained potential issues when using the Core Animation (CA) renderer with complex shapes.
- added a link to the related GitHub issue for reference.

